### PR TITLE
Minor changes

### DIFF
--- a/api/authentication.py
+++ b/api/authentication.py
@@ -105,7 +105,9 @@ class Register(Resource):
         """
         args = REGISTER_PARSER.parse_args()
         if args['email'] == "":
-            return abort(400, "The {email} field cannot be empty")
+            return abort(400, "The {email} field cannot be empty.")
+        if args['fullname'] == "":
+            return abort(400, "The {fullname} field cannot be empty.")
         if "@" not in args['email']:
             return abort(400, "The {email} specified is invalid.")
         if len(args['password']) < 6:

--- a/api/authentication.py
+++ b/api/authentication.py
@@ -104,6 +104,9 @@ class Register(Resource):
             Response -- The Flask response object.
         """
         args = REGISTER_PARSER.parse_args()
+        if args['email'] == "":
+            return abort(400, "The {email} field cannot be empty")
+        if len(args['password'])
         check_auth = Auth.get_by_email(args['email'])
         if check_auth is not None:
             REST_LOGGER.info("auth/register -> Duplicate registration attempt for email %s", args['email'])

--- a/api/authentication.py
+++ b/api/authentication.py
@@ -106,7 +106,10 @@ class Register(Resource):
         args = REGISTER_PARSER.parse_args()
         if args['email'] == "":
             return abort(400, "The {email} field cannot be empty")
-        if len(args['password'])
+        if "@" not in args['email']:
+            return abort(400, "The {email} specified is invalid.")
+        if len(args['password']) < 6:
+            return abort(400, "The {password} given must be >= 6 characters.")
         check_auth = Auth.get_by_email(args['email'])
         if check_auth is not None:
             REST_LOGGER.info("auth/register -> Duplicate registration attempt for email %s", args['email'])

--- a/api/transactions.py
+++ b/api/transactions.py
@@ -62,7 +62,7 @@ class CreateTransaction(Resource):
                 return abort(400, "Invalid {price_purchased} given.")
             if price_purchased <= 0:
                 return abort(400, "The {price_purchased} cannot be less than or equal to 0.")
-        if args['date_sold'] is None:
+        if args['date_sold'] is None or args['date_sold'] == "":
             date_sold = None
             price_sold = None
         else:
@@ -208,17 +208,23 @@ class UpdateTransaction(Resource):
             if args['date_purchased'] is not None:
                 transaction.set_buy_price(purchase_candle.get_close())
         if args['date_sold'] is not None:
-            try:
-                date_sold = parser.parse(args['date_sold'])
-                date_sold = date_sold.replace(tzinfo=None)
-            except Exception:
-                return abort(400, "Invalid {date_sold} specified.")
-            if date_sold > datetime.utcnow():
-                return abort(400, "The {date_sold} cannot be ahead of time.")
-            if date_sold <= date_purchased:
-                return abort(400, "The {date_sold} must be further ahead in time than the {date_purchased}.")
-            transaction.set_sell_date(date_sold)
+            if args['date_sold'] == "":
+                transaction.set_sell_date(None)
+                transaction.set_sell_price(None)
+            else:
+                try:
+                    date_sold = parser.parse(args['date_sold'])
+                    date_sold = date_sold.replace(tzinfo=None)
+                except Exception:
+                    return abort(400, "Invalid {date_sold} specified.")
+                if date_sold > datetime.utcnow():
+                    return abort(400, "The {date_sold} cannot be ahead of time.")
+                if date_sold <= date_purchased:
+                    return abort(400, "The {date_sold} must be further ahead in time than the {date_purchased}.")
+                transaction.set_sell_date(date_sold)
         if args['price_sold'] is not None:
+            if transaction.get_sell_date() is None:
+                return abort(400, "The {price_sold} field cannot be set while {date_sold} hasn't been set.")
             try:
                 price_sold = float(args['price_sold'])
             except Exception:
@@ -227,7 +233,7 @@ class UpdateTransaction(Resource):
                 return abort(400, "The {price_sold} cannot be less than 0.")
             transaction.set_sell_price(price_sold)
         else:
-            if args['date_sold'] is not None:
+            if transaction.get_sell_date() is not None:
                 if date_sold.date() == datetime.utcnow().date():
                     transaction.set_sell_price(transaction.get_asset().get_price())
                 else:

--- a/api/transactions.py
+++ b/api/transactions.py
@@ -60,7 +60,7 @@ class CreateTransaction(Resource):
                 price_purchased = float(args['price_purchased'])
             except Exception:
                 return abort(400, "Invalid {price_purchased} given.")
-            if price_purchased < 0:
+            if price_purchased <= 0:
                 return abort(400, "The {price_purchased} cannot be less than or equal to 0.")
         if args['date_sold'] is None:
             date_sold = None
@@ -223,8 +223,8 @@ class UpdateTransaction(Resource):
                 price_sold = float(args['price_sold'])
             except Exception:
                 return abort(400, "Invalid {price_sold} specified.")
-            if price_sold <= 0:
-                return abort(400, "The {price_sold} cannot be less than or equal to 0.")
+            if price_sold < 0:
+                return abort(400, "The {price_sold} cannot be less than 0.")
             transaction.set_sell_price(price_sold)
         else:
             if args['date_sold'] is not None:

--- a/api/transactions.py
+++ b/api/transactions.py
@@ -51,10 +51,13 @@ class CreateTransaction(Resource):
         if date_purchased > datetime.utcnow():
             return abort(400, "The {date_purchased} cannot be ahead of time.")
         purchase_candle = asset.get_daily_candle(date_purchased)
-        if purchase_candle is None:
+        if purchase_candle is None and date_purchased.date() != datetime.utcnow().date():
             return abort(400, "The given {date_purchased} is prior to the platform's pricing history for the asset.")
         if args['price_purchased'] is None:
-            price_purchased = purchase_candle.get_close()
+            if purchase_candle is None:
+                price_purchased = asset.get_price()
+            else:
+                price_purchased = purchase_candle.get_close()
         else:
             try:
                 price_purchased = float(args['price_purchased'])

--- a/api/transactions.py
+++ b/api/transactions.py
@@ -60,7 +60,7 @@ class CreateTransaction(Resource):
                 price_purchased = float(args['price_purchased'])
             except Exception:
                 return abort(400, "Invalid {price_purchased} given.")
-            if price_purchased <= 0:
+            if price_purchased < 0:
                 return abort(400, "The {price_purchased} cannot be less than or equal to 0.")
         if args['date_sold'] is None:
             date_sold = None

--- a/datafeed/assetclass.py
+++ b/datafeed/assetclass.py
@@ -184,6 +184,7 @@ class CurrencyUpdaterDaily(IntervalUpdater):
                 self.provider.make_request()
                 # Make the request with the given ticker
                 data = self.api.get_currency_exchange_daily(asset.get_ticker(), "USD", outputsize=sync_type)
+                counter = DAILY_MAX_RETRIES
             except Exception as ex:
                 # Log the details of the error if we fail
                 CONFIG.DATA_LOGGER.error("CurrencyUpdaterDaily -> sync_asset() -> 1")
@@ -193,8 +194,6 @@ class CurrencyUpdaterDaily(IntervalUpdater):
                 sleep(CONFIG.ERROR_WAIT_TIME)
                 # Increment the number of failures
                 counter += 1
-                continue
-            break
         # If no data was returned, notify that we failed to sync the data
         if data is None:
             return [False, 0]
@@ -277,7 +276,7 @@ class CurrencyUpdaterDaily(IntervalUpdater):
 class CurrencyUpdaterLive(IntervalUpdater):
     def __init__(self, api, provider):
         self.api = api
-        self.interval = INTERVAL_MINUTE
+        self.interval = CONFIG.LIVE_UPDATE_INTERVAL
         self.last_update = None
         self.name = "Live"
         self.provider = provider
@@ -307,14 +306,13 @@ class CurrencyUpdaterLive(IntervalUpdater):
             try:
                 self.provider.make_request()
                 data = self.api.get_currency_exchange_rate(asset.get_ticker(), "USD")
+                counter = CONFIG.MAX_RETRIES
             except Exception as ex:
                 CONFIG.DATA_LOGGER.error("CurrencyUpdaterLive -> sync_asset() -> 1")
                 CONFIG.DATA_LOGGER.error(str(asset.as_dict()))
                 CONFIG.DATA_LOGGER.exception(str(ex))
                 sleep(CONFIG.ERROR_WAIT_TIME)
                 counter += 1
-                continue
-            break
         if data is None:
             return [False, 0]
         try:
@@ -439,6 +437,7 @@ class StockUpdaterDaily(IntervalUpdater):
                 self.provider.make_request()
                 # Make the request with the given ticker
                 data = self.api.get_daily(asset.get_ticker(), outputsize=sync_type)
+                counter = DAILY_MAX_RETRIES
             except Exception as ex:
                 # Log the details of the error if we fail
                 CONFIG.DATA_LOGGER.error("StockUpdaterDaily -> sync_asset() -> 1")
@@ -448,8 +447,6 @@ class StockUpdaterDaily(IntervalUpdater):
                 sleep(CONFIG.ERROR_WAIT_TIME)
                 # Increment the number of failures
                 counter += 1
-                continue
-            break
         # If no data was returned, notify that we failed to sync the data
         if data is None:
             return [False, 0]
@@ -533,7 +530,7 @@ class StockUpdaterDaily(IntervalUpdater):
 class StockUpdaterLive(IntervalUpdater):
     def __init__(self, api, provider):
         self.api = api
-        self.interval = INTERVAL_MINUTE
+        self.interval = CONFIG.LIVE_UPDATE_INTERVAL
         self.last_update = None
         self.name = "Live"
         self.provider = provider
@@ -572,14 +569,13 @@ class StockUpdaterLive(IntervalUpdater):
             try:
                 self.provider.make_request()
                 data = self.api.get_batch_stock_quotes(symbols=tickers)[0]
+                counter = CONFIG.MAX_RETRIES
             except Exception as ex:
                 CONFIG.DATA_LOGGER.error("StockUpdaterLive -> sync_asset() -> 1")
                 CONFIG.DATA_LOGGER.error(repr(tickers))
                 CONFIG.DATA_LOGGER.exception(str(ex))
                 sleep(CONFIG.ERROR_WAIT_TIME)
                 counter += 1
-                continue
-            break
         if data is None:
             return [False, 0]
         for stock in data:

--- a/datafeed/provider.py
+++ b/datafeed/provider.py
@@ -40,6 +40,11 @@ class Provider(ABC):
         Returns:
             int -- The number of requests that can be made in the next minute.
         """
+        curr_time = int(time()/60)
+        if curr_time != self.time:
+            self.lock.acquire()
+            self.count = 0
+            self.lock.release()
         return self.max_requests-self.count
 
     def make_request(self) -> None:

--- a/local_config.py
+++ b/local_config.py
@@ -1,27 +1,72 @@
 import os
 import logging
+#########
+#MongoDB#
+#########
 
+# The location to connect to MongoDB on
 MONGODB = "mongodb://localhost"
+# The name of the database to store information under
 DB = "fam"
-TOKEN_EXPIRY = False
+# The port the database server is operating on
 PORT = 5000
+
+################
+#Authentication#
+################
+
+# The secret key to use for JWT tokens
 JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "fam")
-REFRESH_INTERVAL = 600
+# Whether or not tokens expire within the JWT
+TOKEN_EXPIRY = False
+
+##########
+#DataLink#
+##########
+
+# The sleeping time between checking whether asset classes need refreshing
+REFRESH_INTERVAL = 60
+# The default live asset price updating interval - default is 60 seconds
+LIVE_UPDATE_INTERVAL = 600
+# The maximum number of worker threads to use when doing DataLink updates
 WORKER_THREADS = 4
+# The time to wait before retrying when an error occurs during obtaining data
 ERROR_WAIT_TIME = 10
+# The maximum number of retries for data before failing and giving up
 MAX_RETRIES = 5
+# Whether to limit the number of stock assets loaded into the platform
 LIMIT_ASSETS = True
+# The number of stock assets the platform is limited to
 LIMIT_ASSETS_QUANTITY = 10
+
+#########
+#Logging#
+#########
+
+# Initialise the logging for the backend
 logging.basicConfig()
+# Setup the logger for the DataLink
 DATA_LOGGER = logging.getLogger("DataLink")
+# The logging level for the DataLink - logging.ERROR is default
 DATA_LOGGER.setLevel(logging.INFO)
+# Setup the logger for the REST API
 REST_LOGGER = logging.getLogger("REST")
+# The logging level for the REST API - logging.ERROR is default
 REST_LOGGER.setLevel(logging.ERROR)
+
+##################
+#AlphaVantage API#
+##################
+
+# The default key used for obtaining AlphaVantage data
 DEFAULT_KEY = "[insert key here]"
+# The file where the AlphaVantage key is stored
+DEFAULT_KEY_LOCATION = "datafeed/defaults/key.txt"
 os.environ['ALPHAVANTAGE_API_KEY'] = DEFAULT_KEY
-if os.path.exists("datafeed/defaults/key.txt"):
+# Load the key from the file if it exists
+if os.path.exists(DEFAULT_KEY_LOCATION):
     try:
-        F = open("datafeed/defaults/key.txt", "r")
+        F = open(DEFAULT_KEY_LOCATION, "r")
         os.environ['ALPHAVANTAGE_API_KEY'] = F.readline().strip()
     except Exception:
         DATA_LOGGER.error("Error occurred loading AlphaVantage API key.")

--- a/models/asset.py
+++ b/models/asset.py
@@ -4,9 +4,12 @@ from bson import ObjectId
 from dateutil.relativedelta import relativedelta
 from mongoengine import Document, DateTimeField, FloatField, Q, ReferenceField, StringField
 
+from local_config import LIVE_UPDATE_INTERVAL
 from models.candle import Candle
 from models.constants import INTERVAL_DAY
 from models.trend import Trend
+
+OFFLINE_THRESHOLD = LIVE_UPDATE_INTERVAL*1.5
 
 class Asset(Document):
     ticker = StringField(required=True)
@@ -307,7 +310,7 @@ class Asset(Document):
         """
         return Trend.get_trends(search_term=self.get_name(), start=start, finish=finish)
 
-    def has_recent_update(self, interval: int = 600) -> bool:
+    def has_recent_update(self, interval: int = (OFFLINE_THRESHOLD)) -> bool:
         """Returns whether the asset current price has been updated recently within an optional specified interval.
         
         Keyword Arguments:

--- a/models/asset.py
+++ b/models/asset.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from bson import ObjectId
 from dateutil.relativedelta import relativedelta
-from mongoengine import Document, DateTimeField, FloatField, ReferenceField, StringField
+from mongoengine import Document, DateTimeField, FloatField, Q, ReferenceField, StringField
 
 from models.candle import Candle
 from models.constants import INTERVAL_DAY
@@ -34,7 +34,7 @@ class Asset(Document):
         Returns:
             QuerySet[Asset] -- An iterable QuerySet containing Assets in the collection which match the query.
         """
-        return Asset.objects(name__contains=name)
+        return Asset.objects(Q(name__istartswith=name) | Q(ticker__istartswith=name))
 
     @staticmethod
     def get() -> 'QuerySet[Asset]':


### PR DESCRIPTION
- Check email isn't empty
- Check email is valid
- Check password length is >= 6
- Permit purchase price equivalent to 0 on update transaction endpoint
- Explain all config settings with comments
- Set UPDATE_INTERVAL check down to 60 seconds and use LIVE_UPDATE_INTERVAL (currently set 600 seconds) for the interval to update live pricing
- Take into account ticker and asset name in autocomplete (starts with, case insensitive)
- Fix get_unused_quota() not checking whether the current minute has expired
- Permit setting 'price_sold' to "" in /transactions/update to remove a sell date